### PR TITLE
Queue

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,12 @@
 -   [ ] `ztr test` runs `ZTR_SETUP_FN` before `eval`ing the input
 -   [ ] `ztr test` runs `ZTR_TEARDOWN_FN` after `eval`ing the input
 
+### Queue
+
+-   [x] `ztr queue <cmd> [<notes>]` queues a command for later testing
+-   [x] `ztr run-queue [(--quiet | -q)]` runs all queued commands
+    -   [x] `(--quiet | -q)` applies `--quiet` to all the `ztr test`s run in the queue
+
 ## Next
 
 ### Functions manually run with every set of tests
@@ -18,13 +24,3 @@
 -   [ ] `ZTR_CLEAN_FN` is a user-definable function
 -   [ ] `ztr clean` runs the clean function
 -   [ ] `ztr reset` is a shorthand for `ztr clean && ztr clear`
-
-## Next next
-
-### Queue
-
--   [ ] `ztr queue <cmd> [<notes>]` queues a command for later testing
--   [ ] `ztr run-queue [(--quiet | -q)] [--summary]` runs all queued commands
-    -   [ ] `(--quiet | -q)` behaves as in `ztr test`
-    -   [ ] `--summary` runs `ztr summary` after the last queued command
-    -   [ ] regardless of whether or not `--summary` is passed, exit code is `$ZTR_COUNT_FAIL`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,10 @@
 
 ### Functions automatically run with every test
 
--   [ ] `ZTR_SETUP_FN` is a user-definable function
--   [ ] `ZTR_TEARDOWN_FN` is a user-definable function
--   [ ] `ztr test` runs `ZTR_SETUP_FN` before `eval`ing the input
--   [ ] `ztr test` runs `ZTR_TEARDOWN_FN` after `eval`ing the input
+-   [x] `ZTR_SETUP_FN` is a user-definable function
+-   [x] `ZTR_TEARDOWN_FN` is a user-definable function
+-   [x] `ztr test` runs `ZTR_SETUP_FN` before `eval`ing the input
+-   [x] `ztr test` runs `ZTR_TEARDOWN_FN` after `eval`ing the input
 
 ### Queue
 
@@ -15,12 +15,7 @@
 -   [x] `ztr run-queue [(--quiet | -q)]` runs all queued commands
     -   [x] `(--quiet | -q)` applies `--quiet` to all the `ztr test`s run in the queue
 
-## Next
-
 ### Functions manually run with every set of tests
 
--   [ ] `ZTR_BOOTSTRAP_FN` is a user-definable function
--   [ ] `ztr bootstrap` runs the bootstrap function
--   [ ] `ZTR_CLEAN_FN` is a user-definable function
--   [ ] `ztr clean` runs the clean function
--   [ ] `ztr reset` is a shorthand for `ztr clean && ztr clear`
+-   [x] `ZTR_BOOTSTRAP_FN` is a user-definable function
+-   [x] `ZTR_CLEAN_FN` is a user-definable function

--- a/man/man1/ztr.1
+++ b/man/man1/ztr.1
@@ -4,9 +4,9 @@ ztr \- zsh test runner
 
 .SH SYNOPSIS
 
-\fBztr clear\fR
-
 \fBztr clear-queue\fR
+
+\fBztr clear-summary\fR
 
 \fBztr queue\fR [[(\fI\-\-quiet | \-q\fR)] <\fIarg\fR> [\fI\-\-emulate <shell>\fR] [\fI\-\-quiet\-emulate\fR] [\fI<name>\fR [\fI<notes>\fR]]]\fR
 
@@ -29,14 +29,14 @@ ztr \- zsh test runner
 .SH Commands
 
 .IP \(bu
-\fBclear\fR
-
-Clear summary.
-
-.IP \(bu
 \fBztr clear-queue\fR
 
 Clear the queue.
+
+.IP \(bu
+\fBclear-summary\fR
+
+Clear the summary.
 
 .IP \(bu
 \fBztr queue\fR [[(\fI\-\-quiet | \-q\fR)] <\fIarg\fR> [\fI\-\-emulate <shell>\fR] [\fI\-\-quiet\-emulate\fR] [\fI<name>\fR [\fI<notes>\fR]]]\fR

--- a/man/man1/ztr.1
+++ b/man/man1/ztr.1
@@ -6,6 +6,12 @@ ztr \- zsh test runner
 
 \fBztr clear\fR
 
+\fBztr clear-queue\fR
+
+\fBztr queue\fR [[(\fI\-\-quiet | \-q\fR)] <\fIarg\fR> [\fI\-\-emulate <shell>\fR] [\fI\-\-quiet\-emulate\fR] [\fI<name>\fR [\fI<notes>\fR]]]\fR
+
+\fBztr run-queue\fR [(\fI\-\-quiet | \-q\fR)]
+
 \fBztr skip\fR [(\fI\-\-quiet | \-q\fR)] <\fIarg\fR> [\fI<name>\fR [\fI<notes>\fR]]\fR
 
 \fBztr summary\fR
@@ -25,7 +31,26 @@ ztr \- zsh test runner
 .IP \(bu
 \fBclear\fR
 
-Clear results.
+Clear summary.
+
+.IP \(bu
+\fBztr clear-queue\fR
+
+Clear the queue.
+
+.IP \(bu
+\fBztr queue\fR [[(\fI\-\-quiet | \-q\fR)] <\fIarg\fR> [\fI\-\-emulate <shell>\fR] [\fI\-\-quiet\-emulate\fR] [\fI<name>\fR [\fI<notes>\fR]]]\fR
+
+Without arguments: print the queued tests.
+
+With arguments: as `ztr test` but the test is queued rather than run.
+
+.IP \(bu
+\fBztr run-queue\fR [(\fI\-\-quiet | \-q\fR)]
+
+Run all queued tests, and then clear the queue.
+
+\fI\-\-quiet runs all tests with the \fI\-\-quiet flag.
 
 .IP \(bu
 \fBskip \fI<arg>\fR [(\fI\-\-quiet | \-q\fR)] [\fI<name>\fR [\fI<notes>\fR]]\fR
@@ -47,7 +72,7 @@ Test \fI<arg>\fR. Pretty-print result and notes unless "quiet".
 
 If your arg will error when passed to `eval`, quote it. If your arg has spaces, quote it.
 
-Optionally change zsh's emulation mode.
+Optionally change zsh\'s emulation mode.
 
 Optionally do not warn when a non-zsh shell is emulated.
 

--- a/man/man1/ztr.1
+++ b/man/man1/ztr.1
@@ -52,6 +52,10 @@ Run all queued tests, and then clear the queue.
 
 \fI\-\-quiet runs all tests with the \fI\-\-quiet flag.
 
+If \fIZTR_BOOTSTRAP_FN\fR is defined, it is run before the first queued test.
+
+If \fIZTR_CLEAN_FN\fR is defined, it is run after the last queued test.
+
 .IP \(bu
 \fBskip \fI<arg>\fR [(\fI\-\-quiet | \-q\fR)] [\fI<name>\fR [\fI<notes>\fR]]\fR
 

--- a/ztr.zsh
+++ b/ztr.zsh
@@ -252,10 +252,8 @@ ztr() {
 
 	typeset -a args
 	typeset -i clear clear_queue queue run_queue run_test skip_test summary
-	typeset -g __ztr_emulation_mode_requested
-	typeset -g __ztr_emulation_mode_used
-	typeset -gi __ztr_quiet
-	typeset -gi __ztr_quiet_emulation_mode
+	typeset -g __ztr_emulation_mode_requested __ztr_emulation_mode_used
+	typeset -gi __ztr_quiet __ztr_quiet_emulation_mode
 
 	__ztr_emulation_mode_requested=$ZTR_EMULATION_MODE
 	__ztr_quiet=$ZTR_QUIET

--- a/ztr.zsh
+++ b/ztr.zsh
@@ -5,6 +5,36 @@
 # v1.2.0
 # Copyright (c) 2021-present Henry Bley-Vroman
 
+__ztr_bootstrap() {
+	emulate -LR zsh
+	__ztr_debugger
+
+	local -a shell_funcs
+	local -i found
+
+	shell_funcs=( ${(k)functions} )
+	found=$(( $shell_funcs[(Ie)ZTR_BOOTSTRAP_FN] ))
+
+	if (( found )); then
+		ZTR_BOOTSTRAP_FN
+	fi
+}
+
+__ztr_clean() {
+	emulate -LR zsh
+	__ztr_debugger
+
+	local -a shell_funcs
+	local -i found
+
+	shell_funcs=( ${(k)functions} )
+	found=$(( $shell_funcs[(Ie)ZTR_CLEAN_FN] ))
+
+	if (( found )); then
+		ZTR_CLEAN_FN
+	fi
+}
+
 __ztr_clear_queue() {
 	typeset -ga +r __ztr_queue
 	__ztr_queue=
@@ -133,6 +163,8 @@ __ztr_run_queue() {
 
 	quiet_saved=$ZTR_QUIET
 
+	__ztr_bootstrap
+
 	ZTR_QUIET=$__ztr_quiet
 
 	for q in $__ztr_queue; do
@@ -140,6 +172,8 @@ __ztr_run_queue() {
 	done
 
 	ZTR_QUIET=quiet_saved
+
+	__ztr_clean
 
 	__ztr_clear_queue
 }

--- a/ztr.zsh
+++ b/ztr.zsh
@@ -5,7 +5,13 @@
 # v1.2.0
 # Copyright (c) 2021-present Henry Bley-Vroman
 
-__ztr_clear() { # Clear counts.
+__ztr_clear_queue() {
+	typeset -ga +r __ztr_queue
+	__ztr_queue=
+	typeset -gar __ztr_queue
+}
+
+__ztr_clear_summary() {
 	emulate -LR zsh
 	__ztr_debugger
 
@@ -14,12 +20,6 @@ __ztr_clear() { # Clear counts.
 	ZTR_RESULTS[passed]=0
 	ZTR_RESULTS[skipped]=0
 	typeset -gAr ZTR_RESULTS
-}
-
-__ztr_clear_queue() {
-	typeset -ga +r __ztr_queue
-	__ztr_queue=
-	typeset -gar __ztr_queue
 }
 
 __ztr_no_color() {
@@ -297,7 +297,7 @@ ztr() {
 	__ztr_debugger
 
 	typeset -a args
-	typeset -i clear clear_queue queue run_queue run_test skip_test summary
+	typeset -i clear_queue clear_summary queue run_queue run_test skip_test summary
 	typeset -g __ztr_emulation_mode_requested __ztr_emulation_mode_used
 	typeset -gi __ztr_quiet __ztr_quiet_emulation_mode
 
@@ -331,12 +331,12 @@ ztr() {
 				__ztr_version
 				return
 				;;
-			"clear")
-				clear=1
-				shift
-				;;
 			"clear-queue")
 				clear_queue=1
+				shift
+				;;
+			"clear-summary")
+				clear_summary=1
 				shift
 				;;
 			# "help" see "--help"
@@ -368,13 +368,13 @@ ztr() {
 		esac
 	done
 
-	if (( clear )); then
-		__ztr_clear
+	if (( clear_queue )); then
+		__ztr_clear_queue
 		return
 	fi
 
-	if (( clear_queue )); then
-		__ztr_clear_queue
+	if (( clear_summary )); then
+		__ztr_clear_summary
 		return
 	fi
 


### PR DESCRIPTION
New commands: `clear-queue`, `queue`, and `run-queue`

New config: `ZTR_BOOTSTRAP_FN`, `ZTR_CLEAN_FN`

Breaking changes: `clear` function renamed to `clear-summary`